### PR TITLE
Improvements to eliminate lags and hangs

### DIFF
--- a/CutBox/CutBox.xcodeproj/project.pbxproj
+++ b/CutBox/CutBox.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		56184E36ECA11A9DEADFCC44 /* Pods_Testing_CutBoxTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2CD751D99A166B816A663FDE /* Pods_Testing_CutBoxTests.framework */; };
+		7C5495DF2276785B0041FA76 /* String+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C5495DE2276785B0041FA76 /* String+Utils.swift */; };
+		7CA72F1A2289BCBC00D5E50B /* String+UtilsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CA72F192289BCBC00D5E50B /* String+UtilsSpec.swift */; };
 		961A49B22065D85D005BC79D /* SearchAndPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961A49B12065D85D005BC79D /* SearchAndPreviewView.swift */; };
 		961A49B62065D8B1005BC79D /* PopupPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961A49B52065D8B1005BC79D /* PopupPanel.swift */; };
 		961A49B82065D8DE005BC79D /* PopupBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961A49B72065D8DE005BC79D /* PopupBackgroundView.swift */; };
@@ -224,6 +226,8 @@
 /* Begin PBXFileReference section */
 		1EB46E1EB3FD89D01B7C87CE /* Pods-CutBox.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CutBox.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CutBox/Pods-CutBox.debug.xcconfig"; sourceTree = "<group>"; };
 		2CD751D99A166B816A663FDE /* Pods_Testing_CutBoxTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Testing_CutBoxTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7C5495DE2276785B0041FA76 /* String+Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Utils.swift"; sourceTree = "<group>"; };
+		7CA72F192289BCBC00D5E50B /* String+UtilsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+UtilsSpec.swift"; sourceTree = "<group>"; };
 		961A49B12065D85D005BC79D /* SearchAndPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAndPreviewView.swift; sourceTree = "<group>"; };
 		961A49B52065D8B1005BC79D /* PopupPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupPanel.swift; sourceTree = "<group>"; };
 		961A49B72065D8DE005BC79D /* PopupBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupBackgroundView.swift; sourceTree = "<group>"; };
@@ -541,6 +545,7 @@
 				96429D58208C12200055D678 /* Array+String+RegexpSearchFilteredSpec.swift */,
 				964CA5372080395B00B9F33E /* Collection+SafeSpec.swift */,
 				96FD7C3420B1028E00818925 /* OrderedSetSpec.swift */,
+				7CA72F192289BCBC00D5E50B /* String+UtilsSpec.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -552,6 +557,7 @@
 				969F9891209AC03700BB3039 /* NSScreen+currentScreenForMouseLocation.swift */,
 				968D7CA22095FF6A00FF1236 /* Array+removeAtIndexes.swift */,
 				964CA5482083296600B9F33E /* String+L10n.swift */,
+				7C5495DE2276785B0041FA76 /* String+Utils.swift */,
 				963AA6452071E15900779697 /* KeyCombo+Archive.swift */,
 				964766682067B82900E7026F /* DisableScrollView.swift */,
 				964766632067A5F100E7026F /* NSObject+fromNib.swift */,
@@ -1196,6 +1202,7 @@
 				96FD7C2020ADBE0100818925 /* JSFuncItemTableRowTextView.swift in Sources */,
 				96A8020A20AACD4E000CBE74 /* OrderedSet.swift in Sources */,
 				965F078D206FD1890032DACD /* AboutPanel.swift in Sources */,
+				7C5495DF2276785B0041FA76 /* String+Utils.swift in Sources */,
 				964CA50F207E6B4300B9F33E /* CutBoxColorTheme.swift in Sources */,
 				967EFEAE20A476D200A525CC /* NSImage+tint.swift in Sources */,
 				96FD7C2820ADBEF300818925 /* JSFuncSearchViewController.swift in Sources */,
@@ -1285,6 +1292,7 @@
 				96FD7C3520B1028E00818925 /* OrderedSetSpec.swift in Sources */,
 				964CA5362080373500B9F33E /* Array+String+SwiftyStringScoreSpec.swift in Sources */,
 				964CA53C2082251800B9F33E /* CutBoxPreferencesService+HistoryLimitSpec.swift in Sources */,
+				7CA72F1A2289BCBC00D5E50B /* String+UtilsSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CutBox/CutBox/Source/App/SearchAndPreview/ClipItems/ClipItemTableRowTextView.swift
+++ b/CutBox/CutBox/Source/App/SearchAndPreview/ClipItems/ClipItemTableRowTextView.swift
@@ -32,6 +32,7 @@ class ClipItemTableRowTextView: ItemTableRowTextView {
 
         self.title.stringValue = titleString
             .trimmingCharacters(in: .whitespacesAndNewlines)
+            .truncate(limit: 1000)
     }
 
 }

--- a/CutBox/CutBox/Source/App/SearchAndPreview/SearchViewController.swift
+++ b/CutBox/CutBox/Source/App/SearchAndPreview/SearchViewController.swift
@@ -156,8 +156,8 @@ class SearchViewController: NSObject {
     }
 
     func updateSearchItemPreview() {
-        let preview = prefs.prepareClips(selectedClips)
-        self.searchView.preview.string = preview
+        var preview = prefs.prepareClips(selectedClips)
+        self.searchView.preview.string = preview.truncate(limit: 50_000)
     }
 
     // swiftlint:disable cyclomatic_complexity

--- a/CutBox/CutBox/Source/App/Services/History/HistoryService.swift
+++ b/CutBox/CutBox/Source/App/Services/History/HistoryService.swift
@@ -48,7 +48,11 @@ class HistoryService: NSObject {
     var defaults: UserDefaults
     var pasteboard: PasteboardWrapperType
     var pollingTimer: Timer?
-    var filterText: String?
+    var filterText: String? {
+        didSet {
+            invalidateCaches()
+        }
+    }
 
     var removeGuard: String?
 
@@ -57,6 +61,7 @@ class HistoryService: NSObject {
     var searchMode: HistorySearchMode {
         set {
             self.defaults.set(newValue.axID(), forKey: searchModeKey)
+            invalidateCaches()
         }
         get {
             if let axID = self.defaults.string(forKey: searchModeKey) {
@@ -71,6 +76,7 @@ class HistoryService: NSObject {
         set {
             internalFavoritesOnly = newValue
             self.defaults.set(newValue, forKey: searchFavoritesOnly)
+            invalidateCaches()
         }
         get {
             return internalFavoritesOnly
@@ -124,56 +130,82 @@ class HistoryService: NSObject {
         if limit > 0 && historyRepo.items.count > limit {
             historyRepo.removeSubrange(limit..<historyRepo.items.count)
         }
+        invalidateCaches()
     }
 
+    private func invalidateCaches() {
+        itemsCache = nil
+        dictCache = nil
+    }
+
+    var itemsCache: [String]?
     var items: [String] {
+        if let cached = itemsCache {
+            return cached
+        }
+
         let historyItems: [String] =
             self.favoritesOnly ?
                 historyRepo.favorites
                 : historyRepo.items
 
-        guard let search = self.filterText, search != ""
-            else { return historyItems }
-
-        switch searchMode {
-        case .fuzzyMatch:
-            return historyItems.fuzzySearchRankedFiltered(
-                search: search,
-                score: Constants.searchFuzzyMatchMinScore)
-        case .regexpAnyCase:
-            return historyItems.regexpSearchFiltered(
-                search: search,
-                options: [.caseInsensitive])
-        case .regexpStrictCase:
-            return historyItems.regexpSearchFiltered(
-                search: search,
-                options: [])
+        let cache: [String]
+        if let search = self.filterText, search != "" {
+            switch searchMode {
+            case .fuzzyMatch:
+                cache = historyItems.fuzzySearchRankedFiltered(
+                    search: search,
+                    score: Constants.searchFuzzyMatchMinScore)
+            case .regexpAnyCase:
+                cache = historyItems.regexpSearchFiltered(
+                    search: search,
+                    options: [.caseInsensitive])
+            case .regexpStrictCase:
+                cache = historyItems.regexpSearchFiltered(
+                    search: search,
+                    options: [])
+            }
+        } else {
+            cache = historyItems
         }
+
+        itemsCache = cache
+        return cache
     }
 
+    var dictCache: [[String: String]]?
     var dict: [[String: String]] {
+        if let cached = dictCache {
+            return cached
+        }
+
         let historyItems: [[String: String]] =
             self.favoritesOnly ?
                 historyRepo.favoritesDict
                 : historyRepo.dict
 
-        guard let search = self.filterText, search != ""
-            else { return historyItems }
-
-        switch searchMode {
-        case .fuzzyMatch:
-            return historyItems.fuzzySearchRankedFiltered(
-                search: search,
-                score: Constants.searchFuzzyMatchMinScore)
-        case .regexpAnyCase:
-            return historyItems.regexpSearchFiltered(
-                search: search,
-                options: [.caseInsensitive])
-        case .regexpStrictCase:
-            return historyItems.regexpSearchFiltered(
-                search: search,
-                options: [])
+        let cache: [[String: String]]
+        if let search = self.filterText, search != "" {
+            switch searchMode {
+            case .fuzzyMatch:
+                cache = historyItems.fuzzySearchRankedFiltered(
+                    search: search,
+                    score: Constants.searchFuzzyMatchMinScore)
+            case .regexpAnyCase:
+                cache = historyItems.regexpSearchFiltered(
+                    search: search,
+                    options: [.caseInsensitive])
+            case .regexpStrictCase:
+                cache = historyItems.regexpSearchFiltered(
+                    search: search,
+                    options: [])
+            }
+        } else {
+            cache = historyItems
         }
+
+        dictCache = cache
+        return cache
     }
 
     var count: Int {
@@ -203,6 +235,7 @@ class HistoryService: NSObject {
 
     func clear() {
         self.historyRepo.clearHistory()
+        invalidateCaches()
         self.events.onNext(.didClearHistory)
     }
 
@@ -222,12 +255,14 @@ class HistoryService: NSObject {
 
         self.historyRepo
             .removeAtIndexes(indexes: indexes)
+        invalidateCaches()
     }
 
     func toggleFavorite(items: IndexSet) {
         let indexes = itemSelectionToHistoryIndexes(items: items)
         self.historyRepo
             .toggleFavorite(indexes: indexes)
+        invalidateCaches()
     }
 
     func saveToDefaults() {

--- a/CutBox/CutBox/Source/App/Services/History/HistoryService.swift
+++ b/CutBox/CutBox/Source/App/Services/History/HistoryService.swift
@@ -138,7 +138,7 @@ class HistoryService: NSObject {
         dictCache = nil
     }
 
-    var itemsCache: [String]?
+    private var itemsCache: [String]?
     var items: [String] {
         if let cached = itemsCache {
             return cached
@@ -173,7 +173,7 @@ class HistoryService: NSObject {
         return cache
     }
 
-    var dictCache: [[String: String]]?
+    private var dictCache: [[String: String]]?
     var dict: [[String: String]] {
         if let cached = dictCache {
             return cached

--- a/CutBox/CutBox/Source/Extensions/String+Utils.swift
+++ b/CutBox/CutBox/Source/Extensions/String+Utils.swift
@@ -1,0 +1,20 @@
+//
+//  String+Utils.swift
+//  CutBox
+//
+//  Created by denis.st on 29/4/19.
+//  Copyright © 2019 ocodo. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    func truncate(limit: Int, trailing: String = "…") -> String {
+        guard limit > 0 else { return "" }
+        if self.count > limit {
+            return String(self.prefix(limit-1)) + trailing
+        } else {
+            return self
+        }
+    }
+}

--- a/CutBox/CutBoxTests/Extensions/String+UtilsSpec.swift
+++ b/CutBox/CutBoxTests/Extensions/String+UtilsSpec.swift
@@ -1,0 +1,49 @@
+//
+//  String+UtilsSpec.swift
+//  CutBoxTests
+//
+//  Created by denis.st on 29/4/19.
+//  Copyright © 2019 ocodo. All rights reserved.
+//
+
+import Quick
+import Nimble
+
+@testable import CutBox
+
+class StringUtilsSpec: QuickSpec {
+    override func spec() {
+        describe("String+Utils") {
+            it("Truncate with limit == 0") {
+                let source   = "123456789.123456789.123"
+                let expected = ""
+                let actual = source.truncate(limit: 0)
+                expect(expected).to(equal(actual))
+            }
+            it("Truncate a long string with ellipsis") {
+                let source   = "123456789.123456789.123"
+                let expected = "123456789.12345…"
+                let actual = source.truncate(limit: 16)
+                expect(expected).to(equal(actual))
+            }
+            it("Don't truncate a string if it short enough") {
+                let source   = "123456789.123456789.123"
+                let expected = source
+                let actual = source.truncate(limit: 100)
+                expect(expected).to(equal(actual))
+            }
+            it("Don't truncate a string with a length equal to a limit") {
+                let source   = "123456789.123456789.123"
+                let expected = source
+                let actual = source.truncate(limit: source.count)
+                expect(expected).to(equal(actual))
+            }
+            it("Don't truncate on a boundary case") {
+                let source   = "123456789.123456789.123"
+                let expected = source
+                let actual = source.truncate(limit: source.count+1)
+                expect(expected).to(equal(actual))
+            }
+        }
+    }
+}


### PR DESCRIPTION
On my clips history (~4k items) I had 2-2.5 seconds lag in search. So I made several improvements, and now the search is instant.

- Caching in history service
- Limit a length of previews to avoid hangs on very large clips