### PR TITLE
Add option to hide the preview panel

### DIFF
--- a/CutBox/CutBox.xcodeproj/project.pbxproj
+++ b/CutBox/CutBox.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		05D7EA5110D05DCD0F0F7701 /* libPods-CutBoxAll-CutBoxUnitTestsCI.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F030A4A521085BE6D02F051 /* libPods-CutBoxAll-CutBoxUnitTestsCI.a */; };
+		34A2908628DD41490024C81C /* PreferencesThemeSelectionView+HidePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BD078A28DC931D004D8586 /* PreferencesThemeSelectionView+HidePreview.swift */; };
+		34A2908728DD414A0024C81C /* PreferencesThemeSelectionView+HidePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BD078A28DC931D004D8586 /* PreferencesThemeSelectionView+HidePreview.swift */; };
+		34BD078B28DC931D004D8586 /* PreferencesThemeSelectionView+HidePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BD078A28DC931D004D8586 /* PreferencesThemeSelectionView+HidePreview.swift */; };
 		7C5495DF2276785B0041FA76 /* String+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C5495DE2276785B0041FA76 /* String+Utils.swift */; };
 		83981C3A4AFFF9FA3DBF5DA2 /* libPods-CutBoxAll-CutBoxUnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5EE7E46181D60133BD574AA9 /* libPods-CutBoxAll-CutBoxUnitTests.a */; };
 		883FF82B9DF08DAE9D649D05 /* libPods-CutBoxAll-CutBox.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D3A9AA28D453AAA8BDF124E3 /* libPods-CutBoxAll-CutBox.a */; };
@@ -412,6 +415,7 @@
 		018EC810279A5E3AA02098F4 /* Pods-CutBoxAll-CutBox.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CutBoxAll-CutBox.debug.xcconfig"; path = "Target Support Files/Pods-CutBoxAll-CutBox/Pods-CutBoxAll-CutBox.debug.xcconfig"; sourceTree = "<group>"; };
 		0AC2B5A8CA48A97AB54B1FD8 /* Pods-CutBoxAll-CutBoxUnitTestsCI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CutBoxAll-CutBoxUnitTestsCI.debug.xcconfig"; path = "Target Support Files/Pods-CutBoxAll-CutBoxUnitTestsCI/Pods-CutBoxAll-CutBoxUnitTestsCI.debug.xcconfig"; sourceTree = "<group>"; };
 		0D2AB320E399C04DE3424ECF /* Pods-CutBox-Testing-CutBoxTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CutBox-Testing-CutBoxTests.debug.xcconfig"; path = "Target Support Files/Pods-CutBox-Testing-CutBoxTests/Pods-CutBox-Testing-CutBoxTests.debug.xcconfig"; sourceTree = "<group>"; };
+		34BD078A28DC931D004D8586 /* PreferencesThemeSelectionView+HidePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PreferencesThemeSelectionView+HidePreview.swift"; sourceTree = "<group>"; };
 		458881EB261BBFF0662C6C70 /* Pods-CutBoxAll-CutBoxUnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CutBoxAll-CutBoxUnitTests.debug.xcconfig"; path = "Target Support Files/Pods-CutBoxAll-CutBoxUnitTests/Pods-CutBoxAll-CutBoxUnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		4CB2A1B284FC8AE1F0159E0D /* Pods-CutBox.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CutBox.release.xcconfig"; path = "Target Support Files/Pods-CutBox/Pods-CutBox.release.xcconfig"; sourceTree = "<group>"; };
 		4D9D267D2A0DC4A830308CA0 /* Pods-CutBoxTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CutBoxTests.release.xcconfig"; path = "Target Support Files/Pods-CutBoxTests/Pods-CutBoxTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -705,6 +709,7 @@
 				96A8020720A8581B000CBE74 /* PreferencesThemeSelectionView.swift */,
 				967EFEB120A519D600A525CC /* PreferencesThemeSelectionView+ThemeSelector.swift */,
 				968D7C942095778800FF1236 /* PreferencesThemeSelectionView+UseCompactUI.swift */,
+				34BD078A28DC931D004D8586 /* PreferencesThemeSelectionView+HidePreview.swift */,
 				96A801BC20A8180F000CBE74 /* PreferencesAdvancedView.xib */,
 				96A8020520A857B5000CBE74 /* PreferencesAdvancedView.swift */,
 				967EFEAF20A5199400A525CC /* PreferencesAdvancedView+HistorySize.swift */,
@@ -1496,6 +1501,7 @@
 				963CB00F28D96812003F9CA5 /* JSFuncSearchTextViewDelegate.swift in Sources */,
 				963CB01028D96812003F9CA5 /* JSFuncItemTableRowTextView.swift in Sources */,
 				963CB01128D96812003F9CA5 /* PreferencesAdvancedView+HistoryLimit.swift in Sources */,
+				34A2908728DD414A0024C81C /* PreferencesThemeSelectionView+HidePreview.swift in Sources */,
 				963CB01228D96812003F9CA5 /* ClipItemTableRowTextView.swift in Sources */,
 				963CB01328D96812003F9CA5 /* AboutPanel.swift in Sources */,
 				963CB01428D96812003F9CA5 /* PreferencesJavascriptTransformView.swift in Sources */,
@@ -1601,6 +1607,7 @@
 				9653490328434742000FD0A1 /* JSFuncSearchTextViewDelegate.swift in Sources */,
 				9653493C284347E8000FD0A1 /* JSFuncItemTableRowTextView.swift in Sources */,
 				965348FE28434735000FD0A1 /* PreferencesAdvancedView+HistoryLimit.swift in Sources */,
+				34A2908628DD41490024C81C /* PreferencesThemeSelectionView+HidePreview.swift in Sources */,
 				9653490F28434752000FD0A1 /* ClipItemTableRowTextView.swift in Sources */,
 				965348E728434728000FD0A1 /* AboutPanel.swift in Sources */,
 				965348F028434735000FD0A1 /* PreferencesJavascriptTransformView.swift in Sources */,
@@ -1715,6 +1722,7 @@
 				965F076E206F58A40032DACD /* SearchViewEvents.swift in Sources */,
 				96FD7C2E20ADC1A400818925 /* JSFuncSearchTextViewDelegate.swift in Sources */,
 				968D7CA32095FF6A00FF1236 /* Array+removeAtIndexes.swift in Sources */,
+				34BD078B28DC931D004D8586 /* PreferencesThemeSelectionView+HidePreview.swift in Sources */,
 				96A8021620AB0AD2000CBE74 /* PreferencesTabView.swift in Sources */,
 				9672FF2F2079C89400E4571E /* HistorySearchMode.swift in Sources */,
 				96E1E598205D243400F994ED /* AppDelegate.swift in Sources */,

--- a/CutBox/CutBox/Localizable.strings
+++ b/CutBox/CutBox/Localizable.strings
@@ -17,6 +17,7 @@
 "cutbox_menu_about" = "About CutBox";
 "cutbox_menu_clear_history" = "Clear History";
 "cutbox_menu_compactui" = "Compact UI";
+"cutbox_menu_hide_preview" = "Hide Preview";
 "cutbox_menu_fuzzy_match" = "Fuzzy Match";
 "cutbox_menu_preferences" = "Preferences";
 "cutbox_menu_quit" = "Quit";
@@ -57,6 +58,8 @@
 "preferences_toggle_cutbox_tooltip" = "Choose a keyboard shortcut to show/hide CutBox";
 "preferences_use_compact_ui" = "Use Compact UI";
 "preferences_use_compact_ui_tooltip" = "Compact UI hides history items and paste preview until you begin searching or press right or up";
+"preferences_hide_preview" = "Hide Preview";
+"preferences_hide_preview_tooltip" = "Hides the preview panel";
 "search_placeholder" = "Search CutBox";
 "search_scope_all" = "Search everything";
 "search_scope_favorites"  = "Search favorites";

--- a/CutBox/CutBox/Source/App/CutBoxController.swift
+++ b/CutBox/CutBox/Source/App/CutBoxController.swift
@@ -15,6 +15,7 @@ typealias StatusItemDescriptor = (Int, String, String?, String?)
 class CutBoxController: NSObject {
 
     var useCompactUI: NSMenuItem!
+    var hidePreview: NSMenuItem!
     var fuzzyMatchModeItem: NSMenuItem!
     var regexpModeItem: NSMenuItem!
     var regexpCaseSensitiveModeItem: NSMenuItem!
@@ -70,6 +71,10 @@ class CutBoxController: NSObject {
         self.prefs.useCompactUI = !self.prefs.useCompactUI
     }
 
+    @objc func hidePreviewClicked(_ sender: NSMenuItem) {
+        self.prefs.hidePreview = !self.prefs.hidePreview
+    }
+
     @objc func searchModeSelect(_ sender: NSMenuItem) {
         searchModeSelectAxID(sender.accessibilityIdentifier())
     }
@@ -117,17 +122,18 @@ class CutBoxController: NSObject {
             (4, "cutbox_menu_regexp_case_match".l7n, "regexpStrictCase", "searchModeSelect:"),
             (5, "---", nil, nil),
             (6, "cutbox_menu_compactui".l7n, nil, "useCompactUIClicked:"),
-            (7, "---", nil, nil),
-            (8, "cutbox_menu_preferences".l7n, nil, "openPreferences:"),
-            (9, "cutbox_menu_clear_history".l7n, nil, "clearHistoryClicked:"),
-            (10, "---", nil, nil),
-            (11, "preferences_javascript_transform_reload".l7n, nil, "reloadJavascript:"),
-            (12, "preferences_color_theme_reload_themes".l7n, nil, "reloadThemes:"),
-            (13, "---", nil, nil),
-            // 14: Sparkle: Check for Updates
+            (7, "cutbox_menu_hide_preview".l7n, nil, "hidePreviewClicked:"),
+            (8, "---", nil, nil),
+            (9, "cutbox_menu_preferences".l7n, nil, "openPreferences:"),
+            (10, "cutbox_menu_clear_history".l7n, nil, "clearHistoryClicked:"),
+            (11, "---", nil, nil),
+            (12, "preferences_javascript_transform_reload".l7n, nil, "reloadJavascript:"),
+            (13, "preferences_color_theme_reload_themes".l7n, nil, "reloadThemes:"),
+            (14, "---", nil, nil),
+            // 15: Sparkle: Check for Updates
             //     It will find and fill the empty slot automatically.
-            (15, "cutbox_menu_about".l7n, nil, "openAboutPanel:"),
-            (16, "cutbox_menu_quit".l7n, nil, "quitClicked:")
+            (16, "cutbox_menu_about".l7n, nil, "openAboutPanel:"),
+            (17, "cutbox_menu_quit".l7n, nil, "quitClicked:")
             //     So number all the indexes correctly, leaving a gap.
         ]
 
@@ -140,8 +146,10 @@ class CutBoxController: NSObject {
                          regexpCaseSensitiveModeItem: menu.item(at: 4)!)
 
         self.useCompactUI = menu.item(at: 6)!
+        self.hidePreview = menu.item(at: 7)!
 
         setCompactUIMenuItem()
+        setHidePreviewMenuItem()
     }
 
     func addMenuItems(menu: NSMenu, descriptor: StatusItemDescriptor) {
@@ -224,6 +232,8 @@ class CutBoxController: NSObject {
                     self.historyService.historyLimit = limit
                 case .compactUISettingChanged(let isOn):
                     self.useCompactUI.state = isOn ? .on : .off
+                case .hidePreviewSettingChanged(let isOn):
+                    self.hidePreview.state = isOn ? .on : .off
                 default:
                     break
                 }
@@ -234,6 +244,11 @@ class CutBoxController: NSObject {
     func setCompactUIMenuItem() {
         self.useCompactUI.title = "preferences_use_compact_ui".l7n
         self.useCompactUI.state = self.prefs.useCompactUI ? .on : .off
+    }
+
+    func setHidePreviewMenuItem() {
+        self.hidePreview.title = "preferences_hide_preview".l7n
+        self.hidePreview.state = self.prefs.hidePreview ? .on : .off
     }
 
     func setModeSelectors(fuzzyMatchModeItem: NSMenuItem,

--- a/CutBox/CutBox/Source/App/JSFuncSearchPreview/JSFuncSearchAndPreviewView+KeyDown.swift
+++ b/CutBox/CutBox/Source/App/JSFuncSearchPreview/JSFuncSearchAndPreviewView+KeyDown.swift
@@ -15,7 +15,7 @@ extension JSFuncSearchAndPreviewView {
         switch (event.key, event.modifiers) {
         case (kVK_UpArrow, _),
              (kVK_DownArrow, _):
-            self.hideItemsAndPreview(false)
+            self.hideSearchResults(false)
             if !JSFuncService.shared.isEmpty {
                 self.itemsList.keyDown(with: event)
             }

--- a/CutBox/CutBox/Source/App/Preferences/PreferencesService/CutBoxPreferencesService.swift
+++ b/CutBox/CutBox/Source/App/Preferences/PreferencesService/CutBoxPreferencesService.swift
@@ -13,6 +13,7 @@ import RxSwift
 enum CutBoxPreferencesEvent {
     case historyLimitChanged(limit: Int)
     case compactUISettingChanged(isOn: Bool)
+    case hidePreviewSettingChanged(isOn: Bool)
     case protectFavoritesChanged(isOn: Bool)
     case javascriptReload
     case themeChanged
@@ -37,6 +38,7 @@ class CutBoxPreferencesService {
     private var kHistoryLimited = "historyLimited"
     private var kHistoryLimit = "historyLimit"
     private var kUseCompactUI = "useCompactUI"
+    private var kHidePreview = "hidePreview"
     private var kProtectFavorites = "protectFavorites"
 
     var events: PublishSubject<CutBoxPreferencesEvent>!
@@ -138,6 +140,16 @@ class CutBoxPreferencesService {
         set {
             defaults.set(newValue, forKey: kUseCompactUI)
             events.onNext(.compactUISettingChanged(isOn: newValue))
+        }
+    }
+
+    var hidePreview: Bool {
+        get {
+            return defaults.bool(forKey: kHidePreview)
+        }
+        set {
+            defaults.set(newValue, forKey: kHidePreview)
+            events.onNext(.hidePreviewSettingChanged(isOn: newValue))
         }
     }
 

--- a/CutBox/CutBox/Source/App/Preferences/PreferencesThemeSelectionView+HidePreview.swift
+++ b/CutBox/CutBox/Source/App/Preferences/PreferencesThemeSelectionView+HidePreview.swift
@@ -1,0 +1,36 @@
+//
+//  PreferencesThemeSelectionView+HidePreview.swift
+//  CutBox
+//
+//  Created by Carlos Enumo on 22/09/22.
+//  Copyright © 2022 Carlos Enumo. All rights reserved.
+//
+
+import RxCocoa
+import RxSwift
+
+extension PreferencesThemeSelectionView {
+
+    func setupHidePreviewControl() {
+        self.hidePreviewCheckbox.title = "preferences_hide_preview".l7n
+        self.hidePreviewCheckbox.toolTip = "preferences_hide_preview_tooltip".l7n
+
+        self.hidePreviewCheckbox.state = self.prefs.hidePreview ? .on : .off
+
+        self.hidePreviewCheckbox
+            .rx
+            .state
+            .map { $0 == .on }
+            .subscribe(onNext: { self.prefs.hidePreview = $0 })
+            .disposed(by: disposeBag)
+
+        self.prefs
+            .events
+            .subscribe(onNext: {
+                if case .hidePreviewSettingChanged(let isOn) = $0 {
+                    self.hidePreviewCheckbox.state = isOn ? .on : .off
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/CutBox/CutBox/Source/App/Preferences/PreferencesThemeSelectionView.swift
+++ b/CutBox/CutBox/Source/App/Preferences/PreferencesThemeSelectionView.swift
@@ -17,6 +17,7 @@ class PreferencesThemeSelectionView: NSView {
     @IBOutlet weak var themeSelectorTitleLabel: NSTextField!
     @IBOutlet weak var themeSelectorMenu: NSPopUpButton!
     @IBOutlet weak var compactUICheckbox: NSButton!
+    @IBOutlet weak var hidePreviewCheckbox: NSButton!
     @IBOutlet weak var reloadThemesButton: NSButton!
 
     override func awakeFromNib() {
@@ -24,6 +25,7 @@ class PreferencesThemeSelectionView: NSView {
 
         self.setupThemeSelector()
         self.setupCompactUIControl()
+        self.setupHidePreviewControl()
     }
 
     @IBAction func themeSelectorMenuChanges(_ sender: NSPopUpButton) {

--- a/CutBox/CutBox/Source/App/Preferences/PreferencesThemeSelectionView.xib
+++ b/CutBox/CutBox/Source/App/Preferences/PreferencesThemeSelectionView.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,13 +15,33 @@
                 <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="B9O-7z-kGb">
                     <rect key="frame" x="60" y="23" width="444" height="270"/>
                     <subviews>
-                        <button verticalHuggingPriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="hPC-e9-vTv">
-                            <rect key="frame" x="-2" y="253" width="446" height="18"/>
-                            <buttonCell key="cell" type="check" title="Compact UI" bezelStyle="regularSquare" imagePosition="left" inset="2" id="mAq-kc-Idb">
-                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                <font key="font" metaFont="system"/>
-                            </buttonCell>
-                        </button>
+                        <stackView distribution="fillEqually" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2fj-pr-W3P">
+                            <rect key="frame" x="0.0" y="254" width="444" height="16"/>
+                            <subviews>
+                                <button verticalHuggingPriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="hPC-e9-vTv">
+                                    <rect key="frame" x="-2" y="-1" width="220" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Compact UI" bezelStyle="regularSquare" imagePosition="left" inset="2" id="mAq-kc-Idb">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                </button>
+                                <button verticalHuggingPriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="zZf-CM-JuY">
+                                    <rect key="frame" x="224" y="-1" width="220" height="18"/>
+                                    <buttonCell key="cell" type="check" title="Hide Preview" bezelStyle="regularSquare" imagePosition="left" inset="2" id="EmF-8U-ryn">
+                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                        <font key="font" metaFont="system"/>
+                                    </buttonCell>
+                                </button>
+                            </subviews>
+                            <visibilityPriorities>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                            </visibilityPriorities>
+                            <customSpacing>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                            </customSpacing>
+                        </stackView>
                         <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="j11-7Y-BHb">
                             <rect key="frame" x="0.0" y="226" width="444" height="20"/>
                             <subviews>
@@ -296,9 +316,9 @@ Please, Don-Bot… look into your hard drive, and open your mercy file! Yep, I r
                         </button>
                     </subviews>
                     <constraints>
-                        <constraint firstItem="hPC-e9-vTv" firstAttribute="centerX" secondItem="B9O-7z-kGb" secondAttribute="centerX" id="0iE-sS-lIf"/>
                         <constraint firstItem="v9D-EP-tpp" firstAttribute="top" secondItem="j11-7Y-BHb" secondAttribute="bottom" constant="8" id="hnj-26-MqG"/>
                         <constraint firstItem="j11-7Y-BHb" firstAttribute="centerX" secondItem="B9O-7z-kGb" secondAttribute="centerX" id="jEv-ub-39n"/>
+                        <constraint firstItem="2fj-pr-W3P" firstAttribute="width" secondItem="B9O-7z-kGb" secondAttribute="width" id="kWY-Sl-bYE"/>
                         <constraint firstAttribute="trailing" secondItem="v9D-EP-tpp" secondAttribute="trailing" id="m1T-vv-9Cr"/>
                     </constraints>
                     <visibilityPriorities>
@@ -322,6 +342,7 @@ Please, Don-Bot… look into your hard drive, and open your mercy file! Yep, I r
             </constraints>
             <connections>
                 <outlet property="compactUICheckbox" destination="hPC-e9-vTv" id="9W9-Y1-KYb"/>
+                <outlet property="hidePreviewCheckbox" destination="zZf-CM-JuY" id="7hj-rV-hQ8"/>
                 <outlet property="reloadThemesButton" destination="SzR-JK-Nne" id="gTg-re-boK"/>
                 <outlet property="themeSelectorMenu" destination="GLA-gc-GY8" id="pZj-Ya-XpQ"/>
                 <outlet property="themeSelectorTitleLabel" destination="sVt-fT-sjS" id="qtE-2Y-gUN"/>

--- a/CutBox/CutBox/Source/App/SearchAndPreview/SearchAndPreview+KeyDownHandler.swift
+++ b/CutBox/CutBox/Source/App/SearchAndPreview/SearchAndPreview+KeyDownHandler.swift
@@ -63,6 +63,10 @@ extension SearchAndPreviewView {
             self.events
                 .onNext(.clearHistory)
 
+        case (kVK_ANSI_P, [.command]):
+            self.events
+                .onNext(.togglePreview)
+
         default:
             return
         }

--- a/CutBox/CutBox/Source/App/SearchAndPreview/SearchAndPreview+KeyDownHandler.swift
+++ b/CutBox/CutBox/Source/App/SearchAndPreview/SearchAndPreview+KeyDownHandler.swift
@@ -15,10 +15,10 @@ extension SearchAndPreviewView {
     override func keyDown(with event: NSEvent) {
         switch (event.key, event.modifiers) {
         case (kVK_LeftArrow, _), (kVK_RightArrow, _):
-            self.hideItemsAndPreview(false)
+            self.hideSearchResults(false)
 
         case (kVK_UpArrow, _), (kVK_DownArrow, _):
-            self.hideItemsAndPreview(false)
+            self.hideSearchResults(false)
             if !HistoryService.shared.items.isEmpty {
                 self.itemsList.keyDown(with: event)
             }

--- a/CutBox/CutBox/Source/App/SearchAndPreview/SearchPreviewViewBase.swift
+++ b/CutBox/CutBox/Source/App/SearchAndPreview/SearchPreviewViewBase.swift
@@ -90,6 +90,10 @@ class SearchPreviewViewBase: NSView {
         self.container.isHidden = bool
     }
 
+    func hidePreview(_ bool: Bool) {
+        self.previewContainer.isHidden = bool
+    }
+
     func setupPlaceholder() {
         filterText
             .map { $0.isEmpty ? self.placeHolderTextString : "" }

--- a/CutBox/CutBox/Source/App/SearchAndPreview/SearchPreviewViewBase.swift
+++ b/CutBox/CutBox/Source/App/SearchAndPreview/SearchPreviewViewBase.swift
@@ -85,7 +85,7 @@ class SearchPreviewViewBase: NSView {
             .scrollRowToVisible(selectedRow)
     }
 
-    func hideItemsAndPreview(_ bool: Bool) {
+    func hideSearchResults(_ bool: Bool) {
         self.bottomBar.isHidden = bool
         self.container.isHidden = bool
     }

--- a/CutBox/CutBox/Source/App/SearchAndPreview/SearchViewController.swift
+++ b/CutBox/CutBox/Source/App/SearchAndPreview/SearchViewController.swift
@@ -156,6 +156,20 @@ class SearchViewController: NSObject {
                 self.searchView.itemsList.reloadData()
             })
             .disposed(by: self.disposeBag)
+
+        self.prefs.events
+            .compactMap {
+                switch $0 {
+                case .hidePreviewSettingChanged(let isOn):
+                    return isOn
+                default:
+                    return nil
+                }
+            }
+            .subscribe(onNext: {
+                self.searchView.hidePreview($0)
+            })
+            .disposed(by: self.disposeBag)
     }
 
     func updateSearchItemPreview() {
@@ -195,6 +209,9 @@ class SearchViewController: NSObject {
                     self.historyService.favoritesOnly = !self.historyService.favoritesOnly
                     self.searchView.itemsList.reloadData()
                     self.searchView.setSearchScopeButton(favoritesOnly: self.historyService.favoritesOnly)
+
+                case .togglePreview:
+                    self.prefs.hidePreview = !self.prefs.hidePreview
 
                 case .toggleFavorite:
                     self.toggleFavoriteItems()

--- a/CutBox/CutBox/Source/App/SearchAndPreview/SearchViewController.swift
+++ b/CutBox/CutBox/Source/App/SearchAndPreview/SearchViewController.swift
@@ -143,9 +143,9 @@ class SearchViewController: NSObject {
             .map { $0.isEmpty }
             .subscribe(onNext: {
                 if self.prefs.useCompactUI {
-                    self.searchView.hideItemsAndPreview($0)
+                    self.searchView.hideSearchResults($0)
                 } else {
-                    self.searchView.hideItemsAndPreview(false)
+                    self.searchView.hideSearchResults(false)
                 }
             })
             .disposed(by: disposeBag)

--- a/CutBox/CutBox/Source/App/SearchAndPreview/SearchViewEvents.swift
+++ b/CutBox/CutBox/Source/App/SearchAndPreview/SearchViewEvents.swift
@@ -26,6 +26,7 @@ enum SearchViewEvents {
     case toggleWrappingStrings
     case toggleJoinStrings
     case toggleSearchScope
+    case togglePreview
 
     case removeSelected
     case toggleFavorite

--- a/CutBox/CutBox/Source/App/SearchAndPreview/SearchViewEvents.swift
+++ b/CutBox/CutBox/Source/App/SearchAndPreview/SearchViewEvents.swift
@@ -19,7 +19,7 @@ enum SearchViewEvents {
     case setSearchMode(HistorySearchMode)
     case clearHistory
     case revealItemsAndPreview
-    case hideItemsAndPreview
+    case hideSearchResults
 
     case toggleTheme
     case toggleSearchMode


### PR DESCRIPTION
The preview panel is a cool feature, but it makes the search results too big and covers a great portion of the screen, specially on an external monitor. I would like to see where I'm pasting the item.

The idea of this PR was to allow us to hide the preview so I could have a super compact popup with only the items list.
I was able to successfully add the option to toggle the preview panel in the menu bar, in Preferences and pressing cmd+P in the search window to easily show the preview when needed.
To completely achieve my goal though, I would need help with the resizing part, because I don't have a clue.