### PR TITLE
Select right-clicked item if it is not in the selected range

### DIFF
--- a/CutBox/CutBox/Source/App/SearchAndPreview/SearchAndPreviewView.swift
+++ b/CutBox/CutBox/Source/App/SearchAndPreview/SearchAndPreviewView.swift
@@ -11,7 +11,7 @@ import Cocoa
 import RxSwift
 import RxCocoa
 
-class SearchAndPreviewView: SearchPreviewViewBase {
+class SearchAndPreviewView: SearchPreviewViewBase, NSMenuDelegate {
 
     @IBOutlet weak var searchModeToggle: NSButton!
     @IBOutlet weak var jsIconButton: NSButton!
@@ -108,8 +108,16 @@ class SearchAndPreviewView: SearchPreviewViewBase {
         let contextMenu = NSMenu()
         contextMenu.addItem(remove)
         contextMenu.addItem(favorite)
+        contextMenu.delegate = self
 
         self.itemsList.menu = contextMenu
+    }
+
+    func menuWillOpen(_ menu: NSMenu) {
+
+        if !itemsList.selectedRowIndexes.map({ Int($0) }).contains(itemsList.clickedRow) {
+            itemsList.selectRowIndexes(IndexSet(integer: itemsList.clickedRow), byExtendingSelection: false)
+        }
     }
 
     override func applyTheme() {


### PR DESCRIPTION
Make context menu select the clicked item if it is not in the selected range.
That avoids confusion if the user thinks they are removing the focused item instead of the selected one (which I certainly did).