### PR TITLE
Scroll to top when searching

### DIFF
--- a/CutBox/CutBox/Source/App/SearchAndPreview/SearchViewController.swift
+++ b/CutBox/CutBox/Source/App/SearchAndPreview/SearchViewController.swift
@@ -155,6 +155,7 @@ class SearchViewController: NSObject {
             .subscribe(onNext: {
                 self.historyService.filterText = $0
                 self.searchView.itemsList.reloadData()
+                self.searchView.itemsList.scrollRowToVisible(0)
             })
             .disposed(by: self.disposeBag)
 


### PR DESCRIPTION
If we scroll down the result list and keep searching, the app doesn't show the top results with the selected item.
In that case, if we don't have the preview panel enabled, it's impossible to know what we are pasting.
This PR makes the result list scroll to the top every time we edit the search input.