### PR TITLE
Fix selected text color in Creamsody theme

### DIFF
--- a/CutBox/CutBox/Source/App/Preferences/ColorTheme/CutBoxColorTheme.swift
+++ b/CutBox/CutBox/Source/App/Preferences/ColorTheme/CutBoxColorTheme.swift
@@ -25,7 +25,8 @@ typealias ClipTheme = (
 typealias PreviewTheme = (
     textColor: NSColor,
     backgroundColor: NSColor,
-    selectedTextBackgroundColor: NSColor
+    selectedTextBackgroundColor: NSColor,
+    selectedTextColor: NSColor
 )
 
 class CutBoxColorTheme {
@@ -36,19 +37,11 @@ class CutBoxColorTheme {
 
     let popupBackgroundColor: NSColor
 
-    let searchText: (cursorColor: NSColor,
-    textColor: NSColor,
-    backgroundColor: NSColor,
-    placeholderTextColor: NSColor)
+    let searchText: SearchTextTheme
 
-    let clip: (backgroundColor: NSColor,
-    textColor: NSColor,
-    highlightColor: NSColor,
-    highlightTextColor: NSColor)
+    let clip: ClipTheme
 
-    let preview: (textColor: NSColor,
-    backgroundColor: NSColor,
-    selectedTextBackgroundColor: NSColor)
+    let preview: PreviewTheme
 
     init(name: String,
          popupBackgroundColor: NSColor,

--- a/CutBox/CutBox/Source/App/Preferences/ColorTheme/CutBoxColorThemeDefinition.swift
+++ b/CutBox/CutBox/Source/App/Preferences/ColorTheme/CutBoxColorThemeDefinition.swift
@@ -52,7 +52,8 @@ extension CutBoxColorTheme {
                   preview: PreviewTheme(
                     textColor: theme.preview.textColor.color!,
                     backgroundColor: theme.preview.backgroundColor.color!,
-                    selectedTextBackgroundColor: theme.preview.selectedTextBackgroundColor.color!
+                    selectedTextBackgroundColor: theme.preview.selectedTextBackgroundColor.color!,
+                    selectedTextColor: theme.preview.selectedTextColor.color!
                   ),
                   spacing: CGFloat(theme.spacing))
     }
@@ -201,11 +202,13 @@ struct Preview: Codable {
     let textColor: String
     let backgroundColor: String
     let selectedTextBackgroundColor: String
+    let selectedTextColor: String
 
     enum CodingKeys: String, CodingKey {
         case textColor
         case backgroundColor
         case selectedTextBackgroundColor
+        case selectedTextColor
     }
 }
 
@@ -230,12 +233,14 @@ extension Preview {
     func with(
       textColor: String? = nil,
       backgroundColor: String? = nil,
-      selectedTextBackgroundColor: String? = nil
+      selectedTextBackgroundColor: String? = nil,
+      selectedTextColor: String? = nil
     ) -> Preview {
         return Preview(
           textColor: textColor ?? self.textColor,
           backgroundColor: backgroundColor ?? self.backgroundColor,
-          selectedTextBackgroundColor: selectedTextBackgroundColor ?? self.selectedTextBackgroundColor
+          selectedTextBackgroundColor: selectedTextBackgroundColor ?? self.selectedTextBackgroundColor,
+          selectedTextColor: selectedTextColor ?? self.selectedTextColor
         )
     }
 

--- a/CutBox/CutBox/Source/App/SearchAndPreview/SearchPreviewViewBase.swift
+++ b/CutBox/CutBox/Source/App/SearchAndPreview/SearchPreviewViewBase.swift
@@ -139,6 +139,6 @@ class SearchPreviewViewBase: NSView {
         preview.textColor = theme.preview.textColor
 
         preview.selectedTextAttributes[.backgroundColor] = theme.preview.selectedTextBackgroundColor
-        preview.selectedTextAttributes[.foregroundColor] = theme.preview.textColor
+        preview.selectedTextAttributes[.foregroundColor] = theme.preview.selectedTextColor
     }
 }

--- a/CutBox/CutBox/themes/00 Darkness.cutboxTheme
+++ b/CutBox/CutBox/themes/00 Darkness.cutboxTheme
@@ -16,7 +16,8 @@
     "preview": {
         "textColor": "#ADC2CC",
         "backgroundColor": "#060707",
-        "selectedTextBackgroundColor": "#163242"
+        "selectedTextBackgroundColor": "#163242",
+        "selectedTextColor": "#ADC2CC"
     },
     "spacing": 1
 }

--- a/CutBox/CutBox/themes/01 Skylight.cutboxTheme
+++ b/CutBox/CutBox/themes/01 Skylight.cutboxTheme
@@ -16,7 +16,8 @@
     "preview": {
         "textColor":                   "#000000",
         "backgroundColor":             "#FEFFFE",
-        "selectedTextBackgroundColor": "#808080"
+        "selectedTextBackgroundColor": "#808080",
+        "selectedTextColor":           "#000000"
     },
     "spacing": 1
 }

--- a/CutBox/CutBox/themes/02 Sandy Beach.cutboxTheme
+++ b/CutBox/CutBox/themes/02 Sandy Beach.cutboxTheme
@@ -16,7 +16,8 @@
     "preview": {
         "textColor":                   "#1C1D1C",
         "backgroundColor":             "#EEE8CB",
-        "selectedTextBackgroundColor": "#99840F"
+        "selectedTextBackgroundColor": "#99840F",
+        "selectedTextColor":           "#1C1D1C"
     },
     "spacing": 1
 }

--- a/CutBox/CutBox/themes/03 Darktooth.cutboxTheme
+++ b/CutBox/CutBox/themes/03 Darktooth.cutboxTheme
@@ -16,7 +16,8 @@
     "preview": {
         "textColor":                   "#E4943C",
         "backgroundColor":             "#141617",
-        "selectedTextBackgroundColor": "#7B6E63"
+        "selectedTextBackgroundColor": "#7B6E63",
+        "selectedTextColor":           "#E4943C"
     },
     "spacing": 1
 }

--- a/CutBox/CutBox/themes/04 Creamsody.cutboxTheme
+++ b/CutBox/CutBox/themes/04 Creamsody.cutboxTheme
@@ -11,12 +11,13 @@
         "backgroundColor":    "#282B32",
         "textColor":          "#86D6FF",
         "highlightColor":     "#8DD0C9",
-        "highlightTextColor": "#86D6FF"
+        "highlightTextColor": "#141617"
     },
     "preview": {
         "textColor":                   "#6CAFD1",
         "backgroundColor":             "#141617",
-        "selectedTextBackgroundColor": "#8DD0C9"
+        "selectedTextBackgroundColor": "#8DD0C9",
+        "selectedTextColor":           "#141617"
     },
     "spacing": 1
 }

--- a/CutBox/CutBox/themes/05 Purplehaze.cutboxTheme
+++ b/CutBox/CutBox/themes/05 Purplehaze.cutboxTheme
@@ -16,7 +16,8 @@
     "preview": {
         "textColor":                   "#E6DDF9",
         "backgroundColor":             "#000000",
-        "selectedTextBackgroundColor": "#9D8DD0"
+        "selectedTextBackgroundColor": "#9D8DD0",
+        "selectedTextColor":           "#E6DDF9"
     },
     "spacing": 1
 }

--- a/CutBox/CutBox/themes/06 Verdant.cutboxTheme
+++ b/CutBox/CutBox/themes/06 Verdant.cutboxTheme
@@ -16,7 +16,8 @@
     "preview": {
         "textColor":                   "#E1F9DD",
         "backgroundColor":             "#000000",
-        "selectedTextBackgroundColor": "#97D08D"
+        "selectedTextBackgroundColor": "#97D08D",
+        "selectedTextColor":           "#E1F9DD"
     },
     "spacing": 1
 }

--- a/CutBox/CutBox/themes/07 Amber Cathode.cutboxTheme
+++ b/CutBox/CutBox/themes/07 Amber Cathode.cutboxTheme
@@ -16,7 +16,8 @@
     "preview": {
         "textColor":                   "#EF7031",
         "backgroundColor":             "#000000",
-        "selectedTextBackgroundColor": "#EC3C1A"
+        "selectedTextBackgroundColor": "#EC3C1A",
+        "selectedTextColor":           "#EF7031"
     },
     "spacing": 1
 }

--- a/CutBox/CutBox/themes/08 macOS.cutboxTheme
+++ b/CutBox/CutBox/themes/08 macOS.cutboxTheme
@@ -16,7 +16,8 @@
     "preview": {
         "textColor":                   "#000000",
         "backgroundColor":             "#F8F8F8",
-        "selectedTextBackgroundColor": "#B2D6FF"
+        "selectedTextBackgroundColor": "#B2D6FF",
+        "selectedTextColor":           "#000000"
     },
     "spacing": 1
 }

--- a/CutBox/CutBox/themes/09 macOS Graphite.cutboxTheme
+++ b/CutBox/CutBox/themes/09 macOS Graphite.cutboxTheme
@@ -16,7 +16,8 @@
     "preview": {
         "textColor":                   "#000000",
         "backgroundColor":             "#F8F8F8",
-        "selectedTextBackgroundColor": "#B2D6FF"
+        "selectedTextBackgroundColor": "#B2D6FF",
+        "selectedTextColor":           "#000000"
     },
     "spacing": 1
 }

--- a/CutBox/CutBoxUnitTests/Preferences/CutBoxThemeSpec.swift
+++ b/CutBox/CutBoxUnitTests/Preferences/CutBoxThemeSpec.swift
@@ -60,7 +60,8 @@ class CutBoxThemeSpec: QuickSpec {
                     PreviewTheme(
                         textColor: "#EEEEEE".color!,
                         backgroundColor: "#000000".color!,
-                        selectedTextBackgroundColor: "#FF0000".color!
+                        selectedTextBackgroundColor: "#FF0000".color!,
+                        selectedTextColor: "#EEEEEE".color!
                     ),
                 spacing: 1.0
             )
@@ -84,7 +85,8 @@ class CutBoxThemeSpec: QuickSpec {
                     "preview": {
                         "textColor": "#EEEEEE",
                         "backgroundColor": "#000000",
-                        "selectedTextBackgroundColor": "#FF0000"
+                        "selectedTextBackgroundColor": "#FF0000",
+                        "selectedTextColor": "#EEEEEE"
                     },
                     "spacing": 1.0
                 }
@@ -112,6 +114,8 @@ class CutBoxThemeSpec: QuickSpec {
                         .to(equal(subjectB.preview.backgroundColor))
                     expect(subjectA.preview.selectedTextBackgroundColor)
                         .to(equal(subjectB.preview.selectedTextBackgroundColor))
+                    expect(subjectA.preview.selectedTextColor)
+                        .to(equal(subjectB.preview.selectedTextColor))
                 }
 
                 it("search") {


### PR DESCRIPTION
I love the Creamsody theme but never get to use it because it was impossible to read the highlighted texts.

### Improvements
- Change the `clip.highlightTextColor` in the Creamsody theme to a darker color.
- Add a new `preview.selectedTextColor` to all themes, copying `textColor` to keep the current behavior.

<img width="910" alt="Screenshot 2022-11-11 at 20 17 13" src="https://user-images.githubusercontent.com/803954/201424844-685a3400-0d5d-4c65-ba99-fc087e6f36c2.png">
